### PR TITLE
Repo reference fix

### DIFF
--- a/cdk/lib/ecs_cdk-stack.ts
+++ b/cdk/lib/ecs_cdk-stack.ts
@@ -99,7 +99,7 @@ export class EcsCdkStack extends cdk.Stack {
     const ecrRepo = new ecr.Repository(this, 'EcrRepo');
 
     const gitHubSource = codebuild.Source.gitHub({
-      owner: 'user-name',
+      owner: 'rob7429',
       repo: 'amazon-ecs-cdk-cicd',
       webhook: true, // optional, default: true if `webhookFilteres` were provided, false otherwise
       webhookFilters: [
@@ -166,7 +166,7 @@ export class EcsCdkStack extends cdk.Stack {
 
     const sourceAction = new codepipeline_actions.GitHubSourceAction({
       actionName: 'GitHub_Source',
-      owner: 'user-name',
+      owner: 'rob7429',
       repo: 'amazon-ecs-cdk-cicd',
       branch: 'master',
       oauthToken: cdk.SecretValue.secretsManager("/my/github/token"),

--- a/cdk/lib/ecs_cdk-stack.ts
+++ b/cdk/lib/ecs_cdk-stack.ts
@@ -100,7 +100,7 @@ export class EcsCdkStack extends cdk.Stack {
 
     const gitHubSource = codebuild.Source.gitHub({
       owner: 'rob7429',
-      repo: 'amazon-ecs-cdk-cicd',
+      repo: 'amazon-ecs-fargate-cdk-cicd',
       webhook: true, // optional, default: true if `webhookFilteres` were provided, false otherwise
       webhookFilters: [
         codebuild.FilterGroup.inEventOf(codebuild.EventAction.PUSH).andBranchIs('master'),
@@ -167,7 +167,7 @@ export class EcsCdkStack extends cdk.Stack {
     const sourceAction = new codepipeline_actions.GitHubSourceAction({
       actionName: 'GitHub_Source',
       owner: 'rob7429',
-      repo: 'amazon-ecs-cdk-cicd',
+      repo: 'amazon-ecs-fargate-cdk-cicd',
       branch: 'master',
       oauthToken: cdk.SecretValue.secretsManager("/my/github/token"),
       //oauthToken: cdk.SecretValue.plainText('<plain-text>'),

--- a/cdk/lib/ecs_cdk-stack.ts
+++ b/cdk/lib/ecs_cdk-stack.ts
@@ -99,7 +99,7 @@ export class EcsCdkStack extends cdk.Stack {
     const ecrRepo = new ecr.Repository(this, 'EcrRepo');
 
     const gitHubSource = codebuild.Source.gitHub({
-      owner: 'rob7429',
+      owner: 'user-name',
       repo: 'amazon-ecs-fargate-cdk-cicd',
       webhook: true, // optional, default: true if `webhookFilteres` were provided, false otherwise
       webhookFilters: [
@@ -166,7 +166,7 @@ export class EcsCdkStack extends cdk.Stack {
 
     const sourceAction = new codepipeline_actions.GitHubSourceAction({
       actionName: 'GitHub_Source',
-      owner: 'rob7429',
+      owner: 'user-name',
       repo: 'amazon-ecs-fargate-cdk-cicd',
       branch: 'master',
       oauthToken: cdk.SecretValue.secretsManager("/my/github/token"),
@@ -235,4 +235,3 @@ export class EcsCdkStack extends cdk.Stack {
   }
 
 }
-


### PR DESCRIPTION
*Description of changes:*

It appears that the AWS samples GIT repository name was changed from amazon-ecs-cdk-cicd to amazon-ecs-cdk-fargate-cicd but references to it in ecs_cdk-stack.ts were not updated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
